### PR TITLE
[KOGITO-8799] Add Kubernetes security profile to Kaniko and builder pods

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -60,8 +60,8 @@ jobs:
         run: |
           wget http://security.ubuntu.com/ubuntu/pool/main/s/shadow/libsubid4_4.11.1+dfsg1-2ubuntu1.1_amd64.deb
           sudo dpkg -i libsubid4_4.11.1+dfsg1-2ubuntu1.1_amd64.deb
-          wget http://ftp.us.debian.org/debian/pool/main/libp/libpod/podman_4.3.1+ds1-6+b1_amd64.deb
-          sudo dpkg -i podman_4.3.1+ds1-6+b1_amd64.deb
+          wget http://ftp.us.debian.org/debian/pool/main/libp/libpod/podman_4.3.1+ds1-6+b2_amd64.deb
+          sudo dpkg -i podman_4.3.1+ds1-6+b2_amd64.deb
       - name: Setup golang
         uses: actions/setup-go@v2
         with:

--- a/builder/kubernetes/kaniko.go
+++ b/builder/kubernetes/kaniko.go
@@ -127,7 +127,7 @@ func addKanikoTaskToPod(ctx context.Context, c client.Client, build *api.Build, 
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: util.Pbool(false),
 			Privileged:               util.Pbool(false),
-			RunAsNonRoot:             util.Pbool(true),
+			RunAsNonRoot:             util.Pbool(false),
 			SeccompProfile: &corev1.SeccompProfile{
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			},


### PR DESCRIPTION
See https://issues.redhat.com/browse/KOGITO-8699
Relaxed Security constraint
<!--

Welcome to the Container Builder! Before contributing, make sure to:

- Rebase your branch on the latest upstream main
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
- Follow the below checklist 

-->

**Description of the change:**


**Motivation for the change:**


**Checklist**

- [ ] Add or Modify a unit test for your change
- [ ] Have you verified that tall the tests are passing?